### PR TITLE
immutable project  has now exactly the same word struct as dummy

### DIFF
--- a/app/src/main/java/com/sdp13epfl2021/projmag/model/ImmutableProject.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/model/ImmutableProject.kt
@@ -4,50 +4,62 @@ sealed class Result<T>
 data class Success<T>(val value: T) : Result<T>()
 data class Failure<T>(val reason: String) : Result<T>()
 
-class ImmutableProject(val name : String,
-                       val labName : String,
-                       val projectManager : String,
-                       val description : String,
-                       val numberStudents: Int,
+
+class ImmutableProject(val id : String,
+                       val name : String,
+                       val lab : String,
+                       val teacher : String,
+                       val TA: String,
+                       val nbParticipant : Int,
+                       val assigned : List<String>,
                        val masterProject : Boolean,
-                       val bachelorSemesterProject : Boolean,
-                       val masterSemesterProject : Boolean,
-                       val assignedStudents : List<String>) {
+                       val bachelorProject : Boolean,
+                       val tags : List<String>,
+                       val isTaken: Boolean,
+                       val description: String
+                        ) {
     companion object {
         const val MAX_NAME_SIZE = 40
         const val MAX_DESCRIPTION_SIZE = 300
         const val MAX_STUDENT_NUMBER = 10
         fun build(
-            name: String, labName: String,
-            projectManager: String,
-            description: String,
-            numberStudents: Int,
-            masterProject: Boolean,
-            bachelorSemesterProject: Boolean,
-            masterSemesterProject: Boolean,
-            assignedStudents: List<String>
+            id : String,
+            name : String,
+            lab : String,
+            teacher : String,
+            TA: String,
+            nbParticipant : Int,
+            assigned : List<String>,
+            masterProject : Boolean,
+            bachelorProject : Boolean,
+            tags : List<String>,
+            isTaken: Boolean,
+            description: String
         ): Result<ImmutableProject> {
             return when {
                 name.length > MAX_NAME_SIZE -> Failure("name is more than $MAX_NAME_SIZE characters")
-                labName.length > MAX_NAME_SIZE -> Failure("lab name is more than $MAX_NAME_SIZE characters")
-                projectManager.length > MAX_NAME_SIZE -> Failure("project manager name is more than $MAX_NAME_SIZE characters")
+                lab.length > MAX_NAME_SIZE -> Failure("lab name is more than $MAX_NAME_SIZE characters")
+                TA.length > MAX_NAME_SIZE -> Failure("project manager name is more than $MAX_NAME_SIZE characters")
+                teacher.length > MAX_NAME_SIZE -> Failure("teacher name is more than $MAX_NAME_SIZE characters")
                 description.length > MAX_DESCRIPTION_SIZE -> Failure("description  is more than $MAX_DESCRIPTION_SIZE characters")
-                numberStudents > MAX_STUDENT_NUMBER -> Failure("max student number for a project is set to $MAX_STUDENT_NUMBER")
-                assignedStudents.size > numberStudents -> Failure(
-                    "there are ${assignedStudents.size} " +
-                            "students assigned but only $numberStudents allowed to work for the project"
+                nbParticipant > MAX_STUDENT_NUMBER -> Failure("max student number for a project is set to $MAX_STUDENT_NUMBER")
+                assigned.size > nbParticipant -> Failure(
+                    "there are ${assigned.size} " +
+                            "students currently assigned but only $nbParticipant allowed to work for the project"
                 )
-                else -> Success(
-                    ImmutableProject(
-                        name,
-                        labName,
-                        projectManager,
-                        description,
-                        numberStudents,
-                        masterProject,
-                        bachelorSemesterProject,
-                        masterSemesterProject,
-                        assignedStudents
+                else -> Success( ImmutableProject(
+                    id,
+                    name,
+                    lab,
+                    teacher,
+                    TA,
+                    nbParticipant,
+                    assigned,
+                    masterProject,
+                    bachelorProject,
+                    tags,
+                    isTaken,
+                    description,
                     )
                 )
             }
@@ -55,29 +67,37 @@ class ImmutableProject(val name : String,
     }
 
 
-
     /**
      * Function that allows copying of a project and modifying only the fields that you wish to modify
      * returns a project wrapped in a success wrapper, or a failure with the explanation wrapped as a string
      *
+     * @param id : project id from firebase
      * @param name : name of the project
-     * @param labName : name of the lab
-     * @param projectManager : name of the project manager
+     * @param lab : lab of the project
+     * @param teacher : person responsible for the lab
+     * @param TA : person responsible for the project
+     * @param nbParticipant : number of participants
+     * @param assigned : list of the assigned students
+     * @param masterProject : is this project available for a 12 credits master project
+     * @param bachelorProject : is this project available as a bachelor semester project
+     * @param tags : tags associated to the project
+     * @param isTaken : Is this project already taken
      * @param description : description of the project
-     * @param numberStudents : possible number of students that can work on this project
-     * @param masterProject : can this project be a master project
-     * @param bachelorSemesterProject : can this project be a bachelor semester project
-     * @param masterSemesterProject : can this project be a master semester project
-     * @param assignedStudents : list of the assigned students to the project
      */
-    fun buildCopy(name: String = this.name, labName: String = this.labName, projectManager: String = this.projectManager
-                  , description: String = this.description, numberStudents: Int = this.numberStudents,
-                  masterProject: Boolean = this.masterProject
-                  , bachelorSemesterProject: Boolean = this.bachelorSemesterProject
-                  , masterSemesterProject: Boolean = this.masterSemesterProject
-                  , assignedStudents: List<String> = this.assignedStudents)
-            = build(name, labName, projectManager, description, numberStudents,
-        masterProject, bachelorSemesterProject, masterSemesterProject, assignedStudents)
+    fun buildCopy(id : String = this.id,
+                  name : String = this.name,
+                  lab : String = this.lab,
+                  teacher : String = this.teacher,
+                  TA : String = this.TA,
+                  nbParticipant : Int = this.nbParticipant,
+                  assigned : List<String> = this.assigned,
+                  masterProject: Boolean = this.masterProject,
+                  bachelorProject: Boolean = this.bachelorProject,
+                  tags: List<String> = this.tags,
+                  isTaken: Boolean = this.isTaken,
+                  description: String = this.description)
+            = build( id, name, lab, teacher, TA, nbParticipant, assigned, masterProject, bachelorProject,
+                    tags, isTaken, description,)
 
 
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/model/TagsBase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/model/TagsBase.kt
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 
 data class TagsBase(
     private val tags: MutableSet<String> = mutableSetOf(),
-    private val MAX_TAG_SIZE : Int = 40
+    private val MAX_TAG_SIZE : Int = 25
 
 ){
     /**

--- a/app/src/test/java/com/sdp13epfl2021/projmag/model/ImmutableProjectTest.kt
+++ b/app/src/test/java/com/sdp13epfl2021/projmag/model/ImmutableProjectTest.kt
@@ -6,35 +6,38 @@ import org.junit.Test
 class ImmutableProjectTest {
     @Test
     fun initializationAndSanitizationTests(){
+        val id = "zoerjfoerfj"
         val name = "epic roblox coding"
         val labName = "roblox labs"
         val projectManager = "kaou el roblox master"
+        val teacher = "kaou el roblox master"
         val description = "epic roblox coding alll freaking day DAMN SON"
         val numberStudents = 3
         val masterProject = true
         val bachelorSemesterProject = true
         val masterSemesterProject = true
         val listStudents = listOf("epic robloxxx programmer")
+        val tags = listOf("robloxprog")
 
 
-        val result = ImmutableProject.build(name, labName, projectManager,
-            description, numberStudents,
-            masterProject, bachelorSemesterProject, masterSemesterProject ,
-            listOf("epic robloxxx programmer"))
+        val result = ImmutableProject.build(id, name, labName, projectManager, teacher, numberStudents,
+            listStudents, true, true, tags, false, description)
         when(result){
             is Success -> {
 
                 //testing the getters
                 val project = result.value
                 Assert.assertEquals(name, project.name)
-                Assert.assertEquals(labName, project.labName)
-                Assert.assertEquals(projectManager, project.projectManager)
+                Assert.assertEquals(labName, project.lab)
+                Assert.assertEquals(teacher, project.teacher)
                 Assert.assertEquals(description, project.description)
-                Assert.assertEquals(numberStudents, project.numberStudents)
+                Assert.assertEquals(numberStudents, project.nbParticipant)
                 Assert.assertEquals(masterProject, project.masterProject)
-                Assert.assertEquals(bachelorSemesterProject, project.bachelorSemesterProject)
-                Assert.assertEquals(masterSemesterProject, project.masterSemesterProject)
-
+                Assert.assertEquals(bachelorSemesterProject, project.bachelorProject)
+                Assert.assertEquals(id, project.id)
+                Assert.assertEquals(true, project.bachelorProject)
+                Assert.assertEquals(true, project.masterProject)
+                Assert.assertEquals(listStudents, project.assigned)
                 //testing the limit of functions
                 val longName = "ultra epic robloxx coder ultimate guy but with a name that's long"
                 when( project.buildCopy(name = longName)){
@@ -43,12 +46,17 @@ class ImmutableProjectTest {
                 }
 
                 val longLabName = "ultra epic robloxxx lab but the name is too long"
-                when( project.buildCopy(labName = longLabName)){
+                when( project.buildCopy(lab = longLabName)){
                     is Success -> assert(false)
                     is Failure -> assert(true)
                 }
 
-                when( project.buildCopy(projectManager = longLabName)){
+                when( project.buildCopy(TA = longLabName)){
+                    is Success -> assert(false)
+                    is Failure -> assert(true)
+                }
+
+                when( project.buildCopy(teacher = longLabName)){
                     is Success -> assert(false)
                     is Failure -> assert(true)
                 }
@@ -64,7 +72,7 @@ class ImmutableProjectTest {
                 }
 
                 val numberStudents = 100
-                when(project.buildCopy(numberStudents = numberStudents)){
+                when(project.buildCopy(nbParticipant = numberStudents)){
                     is Success -> assert(false)
                     is Failure -> assert(true)
                 }


### PR DESCRIPTION
modified immutable project so that it's easier for other programmers to migrate from dummyProject to ImmutableProject by making the word structure exactly the same (same order, same names) as the dummy project.


Added tags and id to the immutable project. Tags dont implement the tag database yet

All the tests pass and there are no major code differences.