### PR TITLE
Fix codeclimate code duplication threshold

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,12 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  similar-code:
+    config:
+      threshold: 120 # not number of lines, but mass threshold (see default analysis configuration)
+  identical-code:
+    config:
+      threshold: 120 # not number of lines, but mass threshold (see default analysis configuration)
+
 exclude_patterns:
 - "**/test/"
 - "**/androidTest/"


### PR DESCRIPTION
Change the threshold for identical-code and similar-code

Be aware that it is **NOT** about _line numbers_, but _MASS THRESHOLD_ relying
on comparison of parsed **AST**s.