### PR TITLE
Change Utils to a singleton

### DIFF
--- a/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectCreationActivity.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectCreationActivity.kt
@@ -190,7 +190,7 @@ class Form : AppCompatActivity() {
          */
         private fun submit(view: View) = Firebase.auth.uid?.let {
             setSubmitButtonEnabled(false) // disable submit, as there is a long time uploading video
-            val utils = Utils(this)
+            val utils = Utils.getInstance(this)
             ProjectUploader(
                 utils.projectsDatabase,
                 utils.fileDatabase,

--- a/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectInformationActivity.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectInformationActivity.kt
@@ -81,7 +81,7 @@ class ProjectInformationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_project_information)
 
-        fileDB = Utils(this).fileDatabase
+        fileDB = Utils.getInstance(this).fileDatabase
 
         // get all the text views that will be set
         val title = findViewById<TextView>(R.id.info_project_title)

--- a/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectsListActivity.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectsListActivity.kt
@@ -38,7 +38,7 @@ class ProjectsListActivity : AppCompatActivity() {
         }
 
         recyclerView = findViewById<RecyclerView>(R.id.recycler_view_project)
-        itemAdapter = ProjectAdapter(this, Utils(this), recyclerView, fromLink, projectId)
+        itemAdapter = ProjectAdapter(this, Utils.getInstance(this), recyclerView, fromLink, projectId)
         recyclerView.adapter = itemAdapter
         recyclerView.setHasFixedSize(false)
 

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -8,7 +8,6 @@ import com.google.firebase.storage.ktx.storage
 import java.io.File
 
 class Utils(
-    context: Context,
     val userDataDatabase: UserDataDatabase,
     val fileDatabase: FileDatabase,
     val metadataDatabase: MetadataDatabase,
@@ -29,12 +28,12 @@ class Utils(
                     FirebaseProjectsDatabase(
                         Firebase.firestore
                     ),
-                    File(context.filesDir, "projects")
+                    File(context.applicationContext.filesDir, "projects")
                 )
             )
         ): Utils {
             if (instance == null) {
-                instance = Utils(context.applicationContext, userDataDB, fileDB, metadataDB, projectsDB)
+                instance = Utils(userDataDB, fileDB, metadataDB, projectsDB)
             }
             return instance!!
         }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -7,16 +7,16 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 import java.io.File
 
-class Utils(private val context: Context) {
-    private val firestore = Firebase.firestore
+class Utils private constructor(context: Context, fb: Firebase) {
+    val firestore = fb.firestore
     // Uncomment to disable firebase cache
     /* val settings = firestoreSettings {
         isPersistenceEnabled = false
     }
     firestore.firestoreSettings = settings*/
 
-    val userDatabase: UserDataDatabase = UserDataFirebase(firestore, Firebase.auth)
-    val fileDatabase: FileDatabase = FirebaseFileDatabase(Firebase.storage, Firebase.auth)
+    val userDatabase: UserDataDatabase = UserDataFirebase(firestore, fb.auth)
+    val fileDatabase: FileDatabase = FirebaseFileDatabase(fb.storage, fb.auth)
     val metadataDatabase: MetadataDatabase = MetadataFirebase(firestore)
     val projectsDatabase: CachedProjectsDatabase =
         CachedProjectsDatabase(
@@ -27,4 +27,16 @@ class Utils(private val context: Context) {
                 File(context.filesDir, "projects")
             )
         )
+
+    companion object {
+        private var instance: Utils? = null
+
+        @Synchronized
+        fun getInstance(context: Context, fb: Firebase = Firebase): Utils {
+            if (instance == null) {
+                instance = Utils(context.applicationContext, fb)
+            }
+            return instance!!
+        }
+    }
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -7,34 +7,34 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 import java.io.File
 
-class Utils private constructor(context: Context, fb: Firebase) {
-    val firestore = fb.firestore
-    // Uncomment to disable firebase cache
-    /* val settings = firestoreSettings {
-        isPersistenceEnabled = false
-    }
-    firestore.firestoreSettings = settings*/
-
-    val userDatabase: UserDataDatabase = UserDataFirebase(firestore, fb.auth)
-    val fileDatabase: FileDatabase = FirebaseFileDatabase(fb.storage, fb.auth)
-    val metadataDatabase: MetadataDatabase = MetadataFirebase(firestore)
-    val projectsDatabase: CachedProjectsDatabase =
-        CachedProjectsDatabase(
-            OfflineProjectDatabase(
-                FirebaseProjectsDatabase(
-                    firestore
-                ),
-                File(context.filesDir, "projects")
-            )
-        )
+class Utils(
+    context: Context,
+    val userDataDatabase: UserDataDatabase,
+    val fileDatabase: FileDatabase,
+    val metadataDatabase: MetadataDatabase,
+    val projectsDatabase: CachedProjectsDatabase,
+) {
 
     companion object {
         private var instance: Utils? = null
 
         @Synchronized
-        fun getInstance(context: Context, fb: Firebase = Firebase): Utils {
+        fun getInstance(
+            context: Context,
+            userDataDB: UserDataDatabase = UserDataFirebase(Firebase.firestore, Firebase.auth),
+            fileDB: FileDatabase = FirebaseFileDatabase(Firebase.storage, Firebase.auth),
+            metadataDB: MetadataDatabase = MetadataFirebase(Firebase.firestore),
+            projectsDB: CachedProjectsDatabase = CachedProjectsDatabase(
+                OfflineProjectDatabase(
+                    FirebaseProjectsDatabase(
+                        Firebase.firestore
+                    ),
+                    File(context.filesDir, "projects")
+                )
+            )
+        ): Utils {
             if (instance == null) {
-                instance = Utils(context.applicationContext, fb)
+                instance = Utils(context.applicationContext, userDataDB, fileDB, metadataDB, projectsDB)
             }
             return instance!!
         }


### PR DESCRIPTION
Using a singleton, it avoid the mentionned problems.
Only a single instance of database could exist with this change.
No leak can happen because context is not stored in Utils anymore.
If we call Utils.getInstance before tests with dummy databases, we can now mock the entire databases.
