### PR TITLE
Feature/offline databases

### DIFF
--- a/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabaseTest.kt
+++ b/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabaseTest.kt
@@ -1,0 +1,83 @@
+package com.sdp13epfl2021.projmag.database
+
+import com.google.common.io.Files
+import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
+import com.sdp13epfl2021.projmag.database.fake.FakeCandidatureDatabase
+import com.sdp13epfl2021.projmag.model.*
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.CompletableFuture
+
+class OfflineCachedCandidatureDatabaseTest {
+
+
+    private val projectId: ProjectId = "001"
+    private val userID = "fakeUserID"
+
+    private val cv: CurriculumVitae = CurriculumVitae(
+        "summary",
+        listOf(
+            CurriculumVitae.Companion.PeriodDescription(
+            "name",
+            "loc",
+            "description",
+            2010,
+            2020
+        )),
+        listOf(),
+        listOf(),
+        listOf()
+    )
+    private val profile: ImmutableProfile = (ImmutableProfile.build(
+        "lastname",
+        "firstname",
+        20,
+        Gender.OTHER,
+        123456,
+        "021 123 45 67",
+        Role.OTHER
+    ) as Success<ImmutableProfile>).value
+
+
+    private val onFailureNotExpected: (Exception) -> Unit = {
+        assert(false)
+    }
+
+    @Test
+    fun candidatureWork() {
+        val tempDir: File = Files.createTempDir()
+        val fakeDB = FakeCandidatureDatabase()
+        val db1: CandidatureDatabase = OfflineCachedCandidatureDatabase(fakeDB, tempDir)
+        val candidature = Candidature(projectId, userID, profile, cv, Candidature.State.Waiting)
+
+        db1.pushCandidature(candidature, Candidature.State.Waiting, {}, onFailureNotExpected)
+
+        val future1: CompletableFuture<List<Candidature>> = CompletableFuture()
+        db1.getListOfCandidatures(projectId, {
+            future1.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(listOf(candidature), future1.get())
+
+
+        val db2: CandidatureDatabase = OfflineCachedCandidatureDatabase(fakeDB, tempDir)
+
+        val future2: CompletableFuture<List<Candidature>> = CompletableFuture()
+        db2.getListOfCandidatures(projectId, {
+            future2.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(listOf(candidature), future2.get())
+
+
+        val emptyDB: CandidatureDatabase = FakeCandidatureDatabase()
+        val db3: CandidatureDatabase = OfflineCachedCandidatureDatabase(emptyDB, tempDir)
+
+        val future3: CompletableFuture<List<Candidature>> = CompletableFuture()
+        db3.getListOfCandidatures(projectId, {
+            future3.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(listOf(candidature), future3.get())
+
+        tempDir.deleteRecursively()
+    }
+}

--- a/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabaseTest.kt
+++ b/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabaseTest.kt
@@ -1,0 +1,125 @@
+package com.sdp13epfl2021.projmag.database
+
+import com.google.common.io.Files
+import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
+import com.sdp13epfl2021.projmag.database.fake.FakeUserDataDatabase
+import junit.framework.TestCase.*
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.CompletableFuture
+
+class OfflineCachedUserDataDatabaseTest {
+
+
+    private val userID = "fakeUserID"
+
+    private val cv: CurriculumVitae = CurriculumVitae(
+        "summary",
+        listOf(CurriculumVitae.Companion.PeriodDescription(
+            "name",
+            "loc",
+            "description",
+            2010,
+            2020
+        )),
+        listOf(),
+        listOf(),
+        listOf()
+    )
+
+
+    private val onFailureNotExpected: (Exception) -> Unit = {
+        assert(false)
+    }
+
+
+    @Test(timeout = 1000)
+    fun cvWork() {
+        val tempDir: File = Files.createTempDir()
+        val fakeDB = FakeUserDataDatabase(userID)
+        val db1: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+
+        db1.pushCv(cv, {}, onFailureNotExpected)
+
+        val result1: CompletableFuture<CurriculumVitae> = CompletableFuture()
+        db1.getCv(userID, {
+            result1.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(cv, result1.get())
+
+        val db2: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+        val result2: CompletableFuture<CurriculumVitae> = CompletableFuture()
+        db1.getCv(userID, {
+            result2.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(cv, result2.get())
+
+        val result3: CompletableFuture<CurriculumVitae?> = CompletableFuture()
+        db1.getCv("333", {
+            result3.complete(it)
+        }, onFailureNotExpected)
+        assertNull(result3.get())
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test(timeout = 1000)
+    fun favoritesWork() {
+        val tempDir: File = Files.createTempDir()
+        val fakeDB = FakeUserDataDatabase(userID)
+        val db1: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+        val expected: List<ProjectId> = listOf("1", "2", "4").sorted()
+
+        db1.pushFavoriteProject("1", {}, onFailureNotExpected)
+        db1.pushFavoriteProject("1", {}, onFailureNotExpected)
+        db1.pushFavoriteProject("3", {}, onFailureNotExpected)
+        db1.removeFromFavorite("2", {}, onFailureNotExpected)
+        db1.removeFromFavorite("3", {}, onFailureNotExpected)
+        db1.pushListOfFavoriteProjects(listOf("2", "4"), {}, onFailureNotExpected)
+
+        val future1: CompletableFuture<List<ProjectId>> = CompletableFuture()
+        db1.getListOfFavoriteProjects({
+            future1.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(expected, future1.get().sorted())
+
+        val db2: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+        val future2: CompletableFuture<List<ProjectId>> = CompletableFuture()
+        db2.getListOfFavoriteProjects({
+            future2.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(expected, future2.get().sorted())
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test(timeout = 1000)
+    fun appliedWork() {
+        val tempDir: File = Files.createTempDir()
+        val fakeDB = FakeUserDataDatabase(userID)
+        val db1: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+        val expected: List<ProjectId> = listOf("2")
+
+        db1.applyUnapply(true, "1", {}, onFailureNotExpected)
+        db1.applyUnapply(true, "2", {}, onFailureNotExpected)
+        db1.applyUnapply(true, "2", {}, onFailureNotExpected)
+        db1.applyUnapply(false, "1", {}, onFailureNotExpected)
+
+        val future1: CompletableFuture<List<ProjectId>> = CompletableFuture()
+        db1.getListOfAppliedToProjects({
+            future1.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(expected, future1.get())
+
+
+        val db2: UserDataDatabase = OfflineCachedUserDataDatabase(fakeDB, userID, tempDir)
+        val future2: CompletableFuture<List<ProjectId>> = CompletableFuture()
+        db2.getListOfAppliedToProjects({
+            future2.complete(it)
+        }, onFailureNotExpected)
+        assertEquals(expected, future2.get())
+
+        tempDir.deleteRecursively()
+    }
+
+}

--- a/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineProjectsDatabaseTest.kt
+++ b/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/OfflineProjectsDatabaseTest.kt
@@ -1,5 +1,6 @@
 package com.sdp13epfl2021.projmag.database
 
+import com.sdp13epfl2021.projmag.database.fake.FakeCandidatureDatabase
 import com.sdp13epfl2021.projmag.database.fake.FakeProjectsDatabase
 import com.sdp13epfl2021.projmag.model.ImmutableProject
 import junit.framework.TestCase.*
@@ -20,6 +21,8 @@ class OfflineProjectsDatabaseTest {
     private val p1 = ImmutableProject("12345","What fraction of Google searches are answered by Wikipedia?","DLAB","authorID23", "Robert West","TA1",1, listOf<String>(),false,true, listOf("data analysis","large datasets","database","systems","database","systems"),false,"Description of project1")
     private val p2 = ImmutableProject("11111","Real-time reconstruction of deformable objects","CVLAB","authorID29", "Teacher2","TA2",1, listOf<String>(),false,true, listOf("Computer Vision","ML"),false,"Description of project2")
     private val p3 = ImmutableProject("00000","Implement a fast driver for a 100 Gb/s network card","DSLAB","authorID31", "Teacher5","TA5",3, listOf<String>(),false,true, listOf("Low Level","Networking","Driver"),false,"Description of project5")
+
+    private val fakeCandidatureDB: CandidatureDatabase = FakeCandidatureDatabase()
 
     private val onFailureNotExpected: ((Exception) -> Unit) = { e ->
         e.printStackTrace()
@@ -72,11 +75,11 @@ class OfflineProjectsDatabaseTest {
     fun shouldNotCrashWithInvalidDir() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, unreadableDir)
+        OfflineProjectDatabase(fakeDB, unreadableDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, unreadableDir)
+        val db2 = OfflineProjectDatabase(emptyDB, unreadableDir, fakeCandidatureDB)
         var result: List<ImmutableProject>? = null
         db2.getAllProjects({
             result = it
@@ -90,7 +93,7 @@ class OfflineProjectsDatabaseTest {
     fun getAllIdsWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, projectsDir)
+        OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         fakeDB.add(p3)
         Thread.sleep(100)
@@ -100,7 +103,7 @@ class OfflineProjectsDatabaseTest {
         Thread.sleep(500)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, projectsDir)
+        val db2 = OfflineProjectDatabase(emptyDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result: List<ProjectId>? = null
@@ -115,7 +118,7 @@ class OfflineProjectsDatabaseTest {
     fun getAllProjectsWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, projectsDir)
+        OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         fakeDB.add(p3)
         Thread.sleep(100)
@@ -123,7 +126,7 @@ class OfflineProjectsDatabaseTest {
         Thread.sleep(100)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, projectsDir)
+        val db2 = OfflineProjectDatabase(emptyDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result: List<ImmutableProject>? = null
@@ -165,7 +168,7 @@ class OfflineProjectsDatabaseTest {
     fun getProjectFromIdWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, projectsDir)
+        OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         fakeDB.add(p3)
         Thread.sleep(100)
@@ -173,7 +176,7 @@ class OfflineProjectsDatabaseTest {
         Thread.sleep(100)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, projectsDir)
+        val db2 = OfflineProjectDatabase(emptyDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result1: ImmutableProject? = null
@@ -195,7 +198,7 @@ class OfflineProjectsDatabaseTest {
     fun getProjectsFromNameWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, projectsDir)
+        OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         fakeDB.add(p3)
         Thread.sleep(100)
@@ -203,7 +206,7 @@ class OfflineProjectsDatabaseTest {
         Thread.sleep(100)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, projectsDir)
+        val db2 = OfflineProjectDatabase(emptyDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result1: List<ImmutableProject>? = null
@@ -225,7 +228,7 @@ class OfflineProjectsDatabaseTest {
     fun getProjectsFromTagsWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        OfflineProjectDatabase(fakeDB, projectsDir)
+        OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         fakeDB.add(p3)
         Thread.sleep(100)
@@ -233,7 +236,7 @@ class OfflineProjectsDatabaseTest {
         Thread.sleep(100)
 
         val emptyDB = FakeProjectsDatabase(listOf())
-        val db2 = OfflineProjectDatabase(emptyDB, projectsDir)
+        val db2 = OfflineProjectDatabase(emptyDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result: List<ImmutableProject>? = null
@@ -250,7 +253,7 @@ class OfflineProjectsDatabaseTest {
     fun pushIsCorrectlyCalled() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        val db = OfflineProjectDatabase(fakeDB, projectsDir)
+        val db = OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         var result: ProjectId? = null
@@ -266,7 +269,7 @@ class OfflineProjectsDatabaseTest {
     fun deleteProjectWithIdIsCorrectlyCalled() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        val db = OfflineProjectDatabase(fakeDB, projectsDir)
+        val db = OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         db.deleteProjectWithId(p2.id, {}, onFailureNotExpected)
@@ -278,7 +281,7 @@ class OfflineProjectsDatabaseTest {
     fun updateVideoWithProjectIsCorrectlyCalled() {
         val projectsList = listOf(p1)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        val db = OfflineProjectDatabase(fakeDB, projectsDir)
+        val db = OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
 
         val uri_1: String = "https://remote/uri/1"
@@ -296,7 +299,7 @@ class OfflineProjectsDatabaseTest {
     fun listenersWorks() {
         val projectsList = listOf(p1, p2)
         val fakeDB = FakeProjectsDatabase(projectsList)
-        val db = OfflineProjectDatabase(fakeDB, projectsDir)
+        val db = OfflineProjectDatabase(fakeDB, projectsDir, fakeCandidatureDB)
         Thread.sleep(500)
         var count: AtomicInteger = AtomicInteger(0)
 

--- a/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/fake/FakeCandidatureDatabase.kt
+++ b/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/fake/FakeCandidatureDatabase.kt
@@ -6,7 +6,8 @@ import com.sdp13epfl2021.projmag.model.Candidature
 
 class FakeCandidatureDatabase(
     val candidaturesState: MutableMap<ProjectId, Map<String, Candidature.State>> = HashMap(),
-    val candidatures: MutableMap<ProjectId, Map<String, Candidature>> = HashMap()
+    val candidatures: MutableMap<ProjectId, Map<String, Candidature>> = HashMap(),
+    val onChanges: MutableMap<ProjectId, MutableList<(ProjectId, List<Candidature>) -> Unit>> = HashMap()
 ) : CandidatureDatabase {
 
     override fun getListOfCandidatures(
@@ -29,6 +30,14 @@ class FakeCandidatureDatabase(
         val newMap2 = candidatures[projectID] ?: emptyMap()
         candidaturesState[projectID] = newMap1 + (userID to newState)
         candidatures[projectID] = newMap2 + (userID to candidature)
+        onChanges[projectID]?.let { it.forEach { it(projectID, candidatures[projectID]?.values?.toList() ?: emptyList()) } }
         onSuccess()
+    }
+
+    override fun addListener(
+        projectID: ProjectId,
+        onChange: (ProjectId, List<Candidature>) -> Unit
+    ) {
+        onChanges[projectID]?.let { it.add(onChange) } ?: run { onChanges[projectID] = mutableListOf(onChange)}
     }
 }

--- a/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/fake/FakeUserDataDatabase.kt
+++ b/app/src/androidTest/java/com/sdp13epfl2021/projmag/database/fake/FakeUserDataDatabase.kt
@@ -3,15 +3,23 @@ package com.sdp13epfl2021.projmag.database.fake
 import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
 import com.sdp13epfl2021.projmag.database.ProjectId
 import com.sdp13epfl2021.projmag.database.UserDataDatabase
-import java.util.Collections.emptyList
+import com.sdp13epfl2021.projmag.model.Candidature
 
-class FakeUserDataDatabase : UserDataDatabase {
+class FakeUserDataDatabase(
+    val userID: String = "",
+    var favorites: MutableSet<ProjectId> = HashSet(),
+    var cvs: MutableMap<String, CurriculumVitae> = HashMap(),
+    var applied: MutableSet<ProjectId> = HashSet(),
+) : UserDataDatabase {
+
+
     override fun pushFavoriteProject(
         projectID: ProjectId,
         onSuccess: () -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        TODO("Not yet implemented")
+        favorites.add(projectID)
+        onSuccess()
     }
 
     override fun pushListOfFavoriteProjects(
@@ -19,14 +27,15 @@ class FakeUserDataDatabase : UserDataDatabase {
         onSuccess: () -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        TODO("Not yet implemented")
+        favorites.addAll(projectIDs)
+        onSuccess()
     }
 
     override fun getListOfFavoriteProjects(
         onSuccess: (List<ProjectId>) -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        TODO("Not yet implemented")
+        onSuccess(favorites.toList())
     }
 
     override fun removeFromFavorite(
@@ -34,30 +43,45 @@ class FakeUserDataDatabase : UserDataDatabase {
         onSuccess: () -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        TODO("Not yet implemented")
+        favorites.remove(projectID)
+        onSuccess()
     }
 
     override fun pushCv(
         cv: CurriculumVitae,
         onSuccess: () -> Unit,
-        onFailure: (java.lang.Exception) -> Unit
+        onFailure: (Exception) -> Unit
     ) {
-        TODO("Not yet implemented")
+        cvs[userID] = cv
+        onSuccess()
+    }
+
+    override fun getCv(
+        userID: String,
+        onSuccess: (CurriculumVitae?) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        onSuccess(cvs[userID])
     }
 
     override fun applyUnapply(
-        applied: Boolean,
-        project: ProjectId,
+        apply: Boolean,
+        projectId: ProjectId,
         onSuccess: () -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        
+        if (apply) {
+            applied.add(projectId)
+        } else {
+            applied.remove(projectId)
+        }
+        onSuccess()
     }
 
     override fun getListOfAppliedToProjects(
         onSuccess: (List<ProjectId>) -> Unit,
         onFailure: (Exception) -> Unit
     ) {
-        onSuccess(ArrayList<ProjectId>())
+        onSuccess(applied.toList())
     }
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectCreationActivity.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/activities/ProjectCreationActivity.kt
@@ -196,6 +196,7 @@ class Form : AppCompatActivity() {
                 utils.projectsDatabase,
                 utils.fileDatabase,
                 utils.metadataDatabase,
+                utils.candidatureDatabase,
                 ::showToast,
                 { setSubmitButtonEnabled(true) },
                 ::finishFromOtherThread

--- a/app/src/main/java/com/sdp13epfl2021/projmag/adapter/CandidatureAdapter.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/adapter/CandidatureAdapter.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.graphics.Color
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -91,13 +92,13 @@ class CandidatureAdapter(activity: Activity, private val utils: Utils, private v
 
     private fun openProfile(context: Context, profile: ImmutableProfile) {
         val intent = Intent(context, MainActivity::class.java) //TODO change to profile view
-        intent.putExtra(MainActivity.profile, profile)
+        intent.putExtra(MainActivity.profile, profile as Parcelable)
         context.startActivity(intent)
     }
 
     private fun openCV(context: Context, cv: CurriculumVitae) {
         val intent = Intent(context, MainActivity::class.java) //TODO change to CV view
-        intent.putExtra(MainActivity.cv, cv)
+        intent.putExtra(MainActivity.cv, cv as Parcelable)
         context.startActivity(intent)
     }
 

--- a/app/src/main/java/com/sdp13epfl2021/projmag/adapter/ProjectAdapter.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/adapter/ProjectAdapter.kt
@@ -2,6 +2,7 @@ package com.sdp13epfl2021.projmag.adapter
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -97,7 +98,7 @@ class ProjectAdapter(private val activity: Activity, private val utils: Utils, p
     fun openProject(holder: ProjectViewHolder, project: ImmutableProject) {
         val context = holder.view.context
         val intent = Intent(context, ProjectInformationActivity::class.java)
-        intent.putExtra(projectString, project)
+        intent.putExtra(projectString, project as Parcelable)
         context.startActivity(intent)
     }
 

--- a/app/src/main/java/com/sdp13epfl2021/projmag/curriculumvitae/CurriculumVitae.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/curriculumvitae/CurriculumVitae.kt
@@ -5,6 +5,7 @@ package com.sdp13epfl2021.projmag.curriculumvitae
 import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 
 /**
@@ -17,7 +18,7 @@ data class CurriculumVitae(
     val jobExperience: List<PeriodDescription>,
     val languages: List<LanguageLevel>,
     val skills: List<SkillDescription>,
-) : Parcelable {
+) : Parcelable, Serializable {
 
     var uri: Uri? = null
         set(value) {
@@ -43,7 +44,7 @@ data class CurriculumVitae(
             val description: String,
             val from: Int,
             val to: Int
-        ) : Validate, Parcelable {
+        ) : Validate, Parcelable, Serializable {
             override fun isValid(): Boolean = name.isNotEmpty() &&
                     location.isNotEmpty() &&
                     description.isNotEmpty() &&
@@ -62,7 +63,7 @@ data class CurriculumVitae(
         data class LanguageLevel(
             val language: String,
             val level: Level
-        ) : Validate, Parcelable {
+        ) : Validate, Parcelable, Serializable {
             companion object {
                 /**
                  * Possible language levels
@@ -103,7 +104,7 @@ data class CurriculumVitae(
         data class SkillDescription(
             val name: String,
             val skillLevel: SkillLevel
-        ) : Validate, Parcelable {
+        ) : Validate, Parcelable, Serializable {
             /**
              * Possible language levels
              */

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/CandidatureDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/CandidatureDatabase.kt
@@ -36,4 +36,8 @@ interface CandidatureDatabase {
         onFailure: (Exception) -> Unit
     )
 
+    fun addListener(
+        projectID: ProjectId,
+        onChange: (ProjectId, List<Candidature>) -> Unit
+    )
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/FirebaseCandidatureDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/FirebaseCandidatureDatabase.kt
@@ -3,6 +3,7 @@ package com.sdp13epfl2021.projmag.database
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.SetOptions
 import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
 import com.sdp13epfl2021.projmag.model.*
@@ -119,6 +120,19 @@ class FirebaseCandidatureDatabase(
             .set(mapOf(candidature.userID to newState), SetOptions.merge())
             .addOnSuccessListener { onSuccess() }
             .addOnFailureListener(onFailure)
+    }
+
+    override fun addListener(
+        projectID: ProjectId,
+        onChange: (ProjectId, List<Candidature>) -> Unit
+    ) {
+        getDoc(projectID)
+            .addSnapshotListener { snapshot, _ ->
+                snapshot?.data?.let {
+                    val candidatures: List<Candidature> = buildCandidature(it, projectID)
+                    onChange(projectID, candidatures)
+                }
+            }
     }
 
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/LocalFileUtils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/LocalFileUtils.kt
@@ -1,0 +1,49 @@
+package com.sdp13epfl2021.projmag.database
+
+import java.io.*
+import kotlin.reflect.KClass
+
+object LocalFileUtils {
+
+    /**
+     * Save a serializable object to a file.
+     *
+     * @param file The file where data will be stored.
+     * @param data The parcelable data to store.
+     * @return if the operation was successful.
+     */
+    fun saveToFile(file: File, data: Serializable) : Boolean {
+        try {
+            ObjectOutputStream(FileOutputStream(file, false)).use {
+                it.writeObject(data)
+                return true
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return false
+        }
+    }
+
+    /**
+     * Load a serialized object from a file.
+     *
+     * @param file The file from which the data is loaded
+     * @param kclass The class type of the data.
+     * @return the data casted to 'type' or null if failed.
+     *
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Serializable> loadFromFile(file: File, kclass: KClass<T>) : T?  {
+        try {
+            ObjectInputStream(FileInputStream(file)).use {
+                return kclass.javaObjectType.cast(it.readObject())
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return null
+        }
+    }
+
+
+
+}

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabase.kt
@@ -63,8 +63,10 @@ class OfflineCachedCandidatureDatabase(
                     c -> remoteList.all { r -> r.userID != c.userID }
                 }
             } ?: emptyList()
+            val totalList = localList + remoteList
+            candidatures[projectID] = totalList
             saveCandidature(projectID)
-            onSuccess(localList + remoteList)
+            onSuccess(totalList)
         }, onFailure)
     }
 

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedCandidatureDatabase.kt
@@ -1,0 +1,78 @@
+package com.sdp13epfl2021.projmag.database
+
+import android.os.Parcelable
+import com.sdp13epfl2021.projmag.model.Candidature
+import kotlinx.parcelize.Parcelize
+import java.io.File
+import java.io.Serializable
+
+
+private const val CANDIDATURE_FILENAME: String = "candidatures.data"
+
+class OfflineCachedCandidatureDatabase(
+    private val db: CandidatureDatabase,
+    private val projectsDir: File
+) : CandidatureDatabase {
+
+    private val candidatures: MutableMap<ProjectId, List<Candidature>> = HashMap()
+
+    init {
+        try {
+            projectsDir.listFiles()?.let { it
+                .filter(File::isDirectory)
+                .mapNotNull(File::listFiles)
+                .mapNotNull { arr -> arr.find { f -> f.parentFile != null && f.name == CANDIDATURE_FILENAME && f.isFile } }
+                .forEach { f ->
+                    candidatures[f.parentFile!!.name] = LocalFileUtils.loadFromFile(f, SerializableCandidatureListWrapper::class)?.list ?: emptyList()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private data class SerializableCandidatureListWrapper(val list: List<Candidature>) :  Serializable
+
+    private fun saveCandidature(projectId: ProjectId) {
+        try {
+            val projectDir: File = File(projectsDir, projectId)
+            projectDir.mkdirs()
+            LocalFileUtils.saveToFile(
+                File(projectDir, CANDIDATURE_FILENAME),
+                SerializableCandidatureListWrapper(candidatures[projectId]!!)
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override fun getListOfCandidatures(
+        projectID: ProjectId,
+        onSuccess: (List<Candidature>) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        db.getListOfCandidatures(projectID, { remoteList ->
+            //If we are offline, the remoteList could be empty or incomplete (cache).
+            //We only keep them if they don't collide, with userID (priority to remote => up to date)
+            val localList = candidatures[projectID]?.let {
+                it.filter {
+                    c -> remoteList.all { r -> r.userID != c.userID }
+                }
+            } ?: emptyList()
+            onSuccess(localList + remoteList)
+        }, onFailure)
+    }
+
+    override fun pushCandidature(
+        candidature: Candidature,
+        newState: Candidature.State,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        val projectId: ProjectId = candidature.projectId
+        val oldList: List<Candidature> = candidatures[projectId] ?: emptyList()
+        candidatures[projectId] = oldList + candidature
+        saveCandidature(projectId)
+        db.pushCandidature(candidature, newState, onSuccess, onFailure)
+    }
+}

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabase.kt
@@ -1,8 +1,6 @@
 package com.sdp13epfl2021.projmag.database
 
-import android.os.Parcelable
 import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
-import kotlinx.parcelize.Parcelize
 import java.io.File
 import java.io.Serializable
 
@@ -10,6 +8,14 @@ private const val CV_FILENAME: String = "cv.data"
 private const val FAVORITES_FILENAME: String = "favorites.data"
 private const val APPLIED_FILENAME: String = "applied.data"
 
+/**
+ * This is an implementation of UserDataDatabase that keep users' data both in persistent storage and memory.
+ * If we are offline and firebase cache is empty/disabled, it will use the data stored locally.
+ * If we are offline and firebase cache is enabled, it will use both the data stored locally and in the cache (priority to `db`).
+ * If we are not offline, it will use the data return by `db` (up to date).
+ *
+ * Favorites/Applied will not use `db` (expect push) because it is only for the local user use.
+ */
 class OfflineCachedUserDataDatabase(
     private val db: UserDataDatabase,
     private val localUserID: String,
@@ -27,7 +33,7 @@ class OfflineCachedUserDataDatabase(
     private val appliedFile: File = File(localUserDir, APPLIED_FILENAME)
     private val cvFile: File = File(localUserDir, CV_FILENAME)
 
-    data class SerializedStringListWrapper(val list: List<String>) : Serializable
+    private data class SerializedStringListWrapper(val list: List<String>) : Serializable
 
     init {
         localUserDir.mkdirs()

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineCachedUserDataDatabase.kt
@@ -1,0 +1,148 @@
+package com.sdp13epfl2021.projmag.database
+
+import android.os.Parcelable
+import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
+import kotlinx.parcelize.Parcelize
+import java.io.File
+import java.io.Serializable
+
+private const val CV_FILENAME: String = "cv.data"
+private const val FAVORITES_FILENAME: String = "favorites.data"
+private const val APPLIED_FILENAME: String = "applied.data"
+
+class OfflineCachedUserDataDatabase(
+    private val db: UserDataDatabase,
+    private val localUserID: String,
+    private val usersDir: File
+
+) : UserDataDatabase {
+
+    private val favorites: MutableSet<ProjectId> = HashSet()
+    private val applied: MutableSet<ProjectId> = HashSet()
+    private val cvs: MutableMap<String, CurriculumVitae> = HashMap()
+
+    private val localUserDir: File = File(usersDir, localUserID)
+
+    private val favoritesFile: File = File(localUserDir, FAVORITES_FILENAME)
+    private val appliedFile: File = File(localUserDir, APPLIED_FILENAME)
+    private val cvFile: File = File(localUserDir, CV_FILENAME)
+
+    data class SerializedStringListWrapper(val list: List<String>) : Serializable
+
+    init {
+        localUserDir.mkdirs()
+        loadUsersData()
+
+        LocalFileUtils.loadFromFile(favoritesFile, SerializedStringListWrapper::class)?.let {
+            favorites.addAll(it.list)
+        }
+        LocalFileUtils.loadFromFile(appliedFile, SerializedStringListWrapper::class)?.let {
+            applied.addAll(it.list)
+        }
+    }
+
+    private fun loadUsersData() {
+        try {
+            usersDir.listFiles()?.forEach { file ->
+                when (file.name) {
+                    CV_FILENAME -> LocalFileUtils.loadFromFile(file, CurriculumVitae::class)?.let { cv ->
+                        file.parent?.let { userID ->
+                            cvs.put(userID, cv)
+                        }
+                    }
+                    //TODO load profiles when merge here
+                    //others
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun saveFavorites() {
+        LocalFileUtils.saveToFile(favoritesFile, SerializedStringListWrapper(favorites.toList()))
+    }
+
+
+
+    override fun pushFavoriteProject(
+        projectID: ProjectId,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        favorites.add(projectID)
+        saveFavorites()
+        db.pushFavoriteProject(projectID, onSuccess, onFailure)
+    }
+
+    override fun pushListOfFavoriteProjects(
+        projectIDs: List<ProjectId>,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        projectIDs.forEach(favorites::add)
+        saveFavorites()
+        db.pushListOfFavoriteProjects(projectIDs, onSuccess, onFailure)
+    }
+
+    override fun getListOfFavoriteProjects(
+        onSuccess: (List<ProjectId>) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        onSuccess(favorites.toList())
+    }
+
+    override fun removeFromFavorite(
+        projectID: ProjectId,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        favorites.remove(projectID)
+        saveFavorites()
+        db.removeFromFavorite(projectID, onSuccess, onFailure)
+    }
+
+    override fun pushCv(
+        cv: CurriculumVitae,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        cvs[localUserID] = cv
+        LocalFileUtils.saveToFile(cvFile, cv)
+        db.pushCv(cv, onSuccess, onFailure)
+    }
+
+    override fun getCv(
+        userID: String,
+        onSuccess: (CurriculumVitae?) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        cvs[userID]?.let {
+            onSuccess(it)
+        } ?: run {
+            db.getCv(userID, onSuccess, onFailure)
+        }
+    }
+
+    override fun applyUnapply(
+        apply: Boolean,
+        projectId: ProjectId,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        if (apply) {
+            applied.add(projectId)
+        } else {
+            applied.remove(projectId)
+        }
+        LocalFileUtils.saveToFile(appliedFile, SerializedStringListWrapper(applied.toList()))
+        db.applyUnapply(apply, projectId, onSuccess, onFailure)
+    }
+
+    override fun getListOfAppliedToProjects(
+        onSuccess: (List<ProjectId>) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        onSuccess(applied.toList())
+    }
+}

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineProjectDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/OfflineProjectDatabase.kt
@@ -13,7 +13,7 @@ import kotlin.collections.HashMap
 private const val PROJECT_DATA_FILE: String = "project.data"
 private val ID_PATTERN: Regex = Regex("^[a-zA-Z0-9]*\$")
 
-class OfflineProjectDatabase(private val db: ProjectsDatabase, private val projectsDir: File) : ProjectsDatabase {
+class OfflineProjectDatabase(private val db: ProjectsDatabase, private val projectsDir: File, candidatureDB: CandidatureDatabase) : ProjectsDatabase {
 
     private var projectsFiles: Map<ProjectId, File> = emptyMap()
     private var listeners: List<((ProjectChange) -> Unit)> = emptyList()
@@ -33,7 +33,10 @@ class OfflineProjectDatabase(private val db: ProjectsDatabase, private val proje
 
         db.getAllProjects({ remoteProjects ->
             GlobalScope.launch(Dispatchers.IO) {
-                remoteProjects.forEach { p -> saveProject(p) }
+                remoteProjects.forEach {
+                    p -> saveProject(p)
+                    candidatureDB.addListener(p.id) { _, _ -> }
+                }
             }
         }, {})
     }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/ProjectUploader.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/ProjectUploader.kt
@@ -21,6 +21,7 @@ class ProjectUploader(
     private val projectDB: ProjectsDatabase,
     private val fileDB: FileDatabase,
     private val metadataDB: MetadataDatabase,
+    private val candidatureDB: CandidatureDatabase,
     private val showMsg: (String) -> Unit,
     private val onFailure: () -> Unit,
     private val onSuccess: () -> Unit
@@ -78,6 +79,7 @@ class ProjectUploader(
         projectDB.pushProject(
             project,
             { id ->
+                candidatureDB.addListener(id) { _, _ -> }
                 videoUri?.let { uri ->
                     uploadVideo(id, uri, subtitles)
                 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/UserDataDatabase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/UserDataDatabase.kt
@@ -82,6 +82,23 @@ interface UserDataDatabase {
     )
 
     /**
+     * Get the cv for the given user.
+     * If no cv was found for this user, onSuccess is called with null.
+     *
+     * Call `onSuccess` if the operation succeeded
+     * Call `onFailure` with an Exception in case of failure
+     *
+     * @param userID the user id of the cv to get
+     * @param onSuccess called on success
+     * @param onFailure called with an exception on failure
+     */
+    fun getCv(
+        userID: String,
+        onSuccess: (CurriculumVitae?) -> Unit,
+        onFailure: (Exception) -> Unit
+    )
+
+    /**
      * Apply or unapply to the given project depending on the value of apply
      * Call `onSuccess` if the operation succeeded
      * Call `onFailure` with an Exception in case of failure

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/UserDataFirebase.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/UserDataFirebase.kt
@@ -139,6 +139,14 @@ class UserDataFirebase(
         }
     }
 
+    override fun getCv(
+        userID: String,
+        onSuccess: (CurriculumVitae?) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        TODO("Not yet implemented")
+    }
+
     override fun applyUnapply(
         apply: Boolean,
         projectId: ProjectId,

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -53,7 +53,7 @@ class Utils(
                         FirebaseProjectsDatabase(
                             Firebase.firestore
                         ),
-                        File(context.applicationContext.filesDir, "projects")
+                        getSubDir(context, "projects")
                     )
                 )
             } else {
@@ -69,7 +69,7 @@ class Utils(
                         auth
                     ),
                     auth.currentUser?.uid ?: "",
-                    File(context.applicationContext.filesDir, "users")
+                    getSubDir(context, "users")
                 )
             } else {
                 instance!!.userDataDatabase
@@ -80,11 +80,15 @@ class Utils(
             return if (reset || instance?.candidatureDatabase == null) {
                 OfflineCachedCandidatureDatabase(
                     FirebaseCandidatureDatabase(Firebase.firestore, auth, userDataDB),
-                    context.applicationContext.filesDir
+                    getSubDir(context, "projects")
                 )
             } else {
                 instance!!.candidatureDatabase
             }
+        }
+
+        private fun getSubDir(context: Context, subName: String): File {
+            return File(context.applicationContext.filesDir, subName)
         }
     }
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -38,7 +38,7 @@ class Utils(
             candidatureDB: CandidatureDatabase = createCandidatureDB(context, auth, userDataDB, reset),
             fileDB: FileDatabase = FirebaseFileDatabase(Firebase.storage, auth),
             metadataDB: MetadataDatabase = MetadataFirebase(Firebase.firestore),
-            projectsDB: ProjectsDatabase = createProjectsDB(context, reset)
+            projectsDB: ProjectsDatabase = createProjectsDB(context, candidatureDB, reset)
         ): Utils {
             if (instance == null || reset) {
                 instance = Utils(auth, userDataDB, candidatureDB, fileDB, metadataDB, projectsDB)
@@ -46,14 +46,15 @@ class Utils(
             return instance!!
         }
 
-        private fun createProjectsDB(context: Context, reset: Boolean): ProjectsDatabase {
+        private fun createProjectsDB(context: Context, candidatureDB: CandidatureDatabase, reset: Boolean): ProjectsDatabase {
             return if (reset || instance?.projectsDatabase == null) {
                 CachedProjectsDatabase(
                     OfflineProjectDatabase(
                         FirebaseProjectsDatabase(
                             Firebase.firestore
                         ),
-                        getSubDir(context, "projects")
+                        getSubDir(context, "projects"),
+                        candidatureDB
                     )
                 )
             } else {

--- a/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/database/Utils.kt
@@ -34,27 +34,57 @@ class Utils(
             context: Context,
             reset: Boolean = false,
             auth: FirebaseAuth = Firebase.auth,
-            userDataDB: UserDataDatabase = UserDataFirebase(Firebase.firestore, auth),
-            candidatureDB: CandidatureDatabase = FirebaseCandidatureDatabase(Firebase.firestore, auth, userDataDB),
+            userDataDB: UserDataDatabase = createUserDB(context, auth, reset),
+            candidatureDB: CandidatureDatabase = createCandidatureDB(context, auth, userDataDB, reset),
             fileDB: FileDatabase = FirebaseFileDatabase(Firebase.storage, auth),
             metadataDB: MetadataDatabase = MetadataFirebase(Firebase.firestore),
-            projectsDB: ProjectsDatabase? = null //avoid creating an offline database every time the function is called
+            projectsDB: ProjectsDatabase = createProjectsDB(context, reset)
         ): Utils {
             if (instance == null || reset) {
-                instance = Utils(auth, userDataDB, candidatureDB, fileDB, metadataDB, projectsDB ?: createProjectsDB(context))
+                instance = Utils(auth, userDataDB, candidatureDB, fileDB, metadataDB, projectsDB)
             }
             return instance!!
         }
 
-        private fun createProjectsDB(context: Context): ProjectsDatabase {
-            return CachedProjectsDatabase(
-                OfflineProjectDatabase(
-                    FirebaseProjectsDatabase(
-                        Firebase.firestore
-                    ),
-                    File(context.applicationContext.filesDir, "projects")
+        private fun createProjectsDB(context: Context, reset: Boolean): ProjectsDatabase {
+            return if (reset || instance?.projectsDatabase == null) {
+                CachedProjectsDatabase(
+                    OfflineProjectDatabase(
+                        FirebaseProjectsDatabase(
+                            Firebase.firestore
+                        ),
+                        File(context.applicationContext.filesDir, "projects")
+                    )
                 )
-            )
+            } else {
+                instance!!.projectsDatabase
+            }
+        }
+
+        private fun createUserDB(context: Context, auth: FirebaseAuth, reset: Boolean): UserDataDatabase {
+            return if (reset || instance?.userDataDatabase == null) {
+                OfflineCachedUserDataDatabase(
+                    UserDataFirebase(
+                        Firebase.firestore,
+                        auth
+                    ),
+                    auth.currentUser?.uid ?: "",
+                    File(context.applicationContext.filesDir, "users")
+                )
+            } else {
+                instance!!.userDataDatabase
+            }
+        }
+
+        private fun createCandidatureDB(context: Context, auth: FirebaseAuth, userDataDB: UserDataDatabase, reset: Boolean): CandidatureDatabase {
+            return if (reset || instance?.candidatureDatabase == null) {
+                OfflineCachedCandidatureDatabase(
+                    FirebaseCandidatureDatabase(Firebase.firestore, auth, userDataDB),
+                    context.applicationContext.filesDir
+                )
+            } else {
+                instance!!.candidatureDatabase
+            }
         }
     }
 }

--- a/app/src/main/java/com/sdp13epfl2021/projmag/model/Candidature.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/model/Candidature.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
 import com.sdp13epfl2021.projmag.database.ProjectId
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 @Parcelize
 data class Candidature(
@@ -12,7 +13,7 @@ data class Candidature(
     val profile: ImmutableProfile,
     val cv: CurriculumVitae,
     val state: State
-) : Parcelable {
+) : Parcelable, Serializable {
 
     enum class State {
         Waiting, Accepted, Rejected;

--- a/app/src/main/java/com/sdp13epfl2021/projmag/model/ImmutableProfile.kt
+++ b/app/src/main/java/com/sdp13epfl2021/projmag/model/ImmutableProfile.kt
@@ -2,11 +2,12 @@ package com.sdp13epfl2021.projmag.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 @Parcelize
-class ImmutableProfile private constructor(val lastName : String, val firstName : String,
+data class ImmutableProfile private constructor(val lastName : String, val firstName : String,
                                            val age : Int, val gender : Gender, val sciper : Int?, val phoneNumber : String, val role : Role) :
-    Parcelable {
+    Parcelable, Serializable {
 
     companion object{
         private const val MAX_LAST_NAME_SIZE = 40

--- a/app/src/test/java/com/sdp13epfl2021/projmag/database/LocalFileUtilsTest.kt
+++ b/app/src/test/java/com/sdp13epfl2021/projmag/database/LocalFileUtilsTest.kt
@@ -1,0 +1,37 @@
+package com.sdp13epfl2021.projmag.database
+
+import android.os.Parcelable
+import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
+import com.sdp13epfl2021.projmag.model.ImmutableProject
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import kotlinx.parcelize.Parcelize
+import org.junit.After
+import org.junit.Test
+import java.io.File
+import java.io.Serializable
+import java.nio.file.Files
+
+class LocalFileUtilsTest {
+
+    private data class SerializableClassForTesting(val list: List<String>, private val num: Int, val s: String) : Serializable
+
+    private val validFile: File = Files.createTempFile("testing", ".tmp").toFile()
+
+
+    @After
+    fun clean() {
+        validFile.deleteRecursively()
+    }
+
+    @Test
+    fun saveLoadWork() {
+        val data = SerializableClassForTesting(listOf("a", "", "c"), 123, "test")
+        LocalFileUtils.saveToFile(validFile, data)
+        assertEquals(data, LocalFileUtils.loadFromFile(validFile, SerializableClassForTesting::class))
+
+        val result: CurriculumVitae? = LocalFileUtils.loadFromFile(validFile, CurriculumVitae::class)
+        assertNull(result)
+    }
+
+}

--- a/app/src/test/java/com/sdp13epfl2021/projmag/database/LocalFileUtilsTest.kt
+++ b/app/src/test/java/com/sdp13epfl2021/projmag/database/LocalFileUtilsTest.kt
@@ -1,11 +1,8 @@
 package com.sdp13epfl2021.projmag.database
 
-import android.os.Parcelable
 import com.sdp13epfl2021.projmag.curriculumvitae.CurriculumVitae
-import com.sdp13epfl2021.projmag.model.ImmutableProject
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
-import kotlinx.parcelize.Parcelize
 import org.junit.After
 import org.junit.Test
 import java.io.File

--- a/app/src/test/java/com/sdp13epfl2021/projmag/database/ProjectUploaderTest.kt
+++ b/app/src/test/java/com/sdp13epfl2021/projmag/database/ProjectUploaderTest.kt
@@ -18,6 +18,8 @@ class ProjectUploaderTest {
 
     val mockMetadataDB = Mockito.mock(MetadataDatabase::class.java)
 
+    val mockCandidatureDB = Mockito.mock(CandidatureDatabase::class.java)
+
     val mockUri = Mockito.mock(Uri::class.java)
     val subtitles = "not formatted subtitles, but we do not really care here"
 
@@ -99,6 +101,7 @@ class ProjectUploaderTest {
             mockProjectDB,
             mockFileDB,
             mockMetadataDB,
+            mockCandidatureDB,
             { msg -> assertEquals(reason, msg) },
             {},
             {}).checkProjectAndThenUpload(
@@ -114,6 +117,7 @@ class ProjectUploaderTest {
             mockProjectDB,
             mockFileDB,
             mockMetadataDB,
+            mockCandidatureDB,
             { msg -> assertEquals("Project pushed (without video) with ID : $PID", msg) },
             {},
             {}).checkProjectAndThenUpload(
@@ -129,6 +133,7 @@ class ProjectUploaderTest {
             mockProjectDB,
             mockFileDB,
             mockMetadataDB,
+            mockCandidatureDB,
             { msg -> assertEquals("Project pushed with ID : $PID", msg) },
             {},
             {}).checkProjectAndThenUpload(
@@ -144,6 +149,7 @@ class ProjectUploaderTest {
             mockProjectDB,
             mockFileDB,
             mockMetadataDB,
+            mockCandidatureDB,
             { msg -> assertEquals("Project pushed with ID : $PID", msg) },
             {},
             {}).checkProjectAndThenUpload(


### PR DESCRIPTION
In this branch, offline & cached implementation of some databases are added.
Persistent storage is used for many different type of data and LocalFileUtils can save/load serializable data to/from file easily.
for example : 
```
val success: Boolean = LocalFileUtils.saveToFile(profileFile, profile1)
val profile2: ImmutableProfile? = LocalFileUtils.loadFromFile(profileFile, ImmutableProfile::class)
```

Now, the local storage is organized in this way : 

../projects/{projectId}/
- project.data
- candidatures.data
- "videos/others files"


../users/{userID}/
- applied.data
- cv.data
- favorites.data
- profile.data (not implemented yet, to do after #154)
